### PR TITLE
added multiLineOnly option to default options

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ options: {
   sidebarState: true,
   exclude: false,
   lineNums: false,
+  multiLineOnly: false,
   js: [],
   css: [],
   extras: []


### PR DESCRIPTION
The `multiLineOnly` option was introduced in Docker v.0.2.13.
If enabled, in JavaScript

``` js
/*
some comment,
...
*/
```

will be parsed as Markdown, while

``` js
// some comment
// ...
```

will be put inside the code.
